### PR TITLE
Respond to OPTIONS request immediately, do not yield next.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ module.exports = function(settings) {
      */
     if (this.method === 'OPTIONS') {
       this.status = 204;
+      return;
     }
     
     return yield next;


### PR DESCRIPTION
There is no need to yield next if we have an OPTIONS request as we should process the response immediately.
