### PR TITLE
Fix origin mirroring persisting from initial request

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  * @api public
  */
 module.exports = function(settings) {
-  
+
   var defaults = {
     origin: '*',
     methods: 'GET,HEAD,PUT,POST,DELETE'
@@ -15,31 +15,37 @@ module.exports = function(settings) {
   settings = settings || defaults;
 
   return function* cors(next) {
-    
+
     yield next;
-    
-    var options = settings;
-    
+
+    var options = {
+      origin:      settings.origin,
+      methods:     settings.methods,
+      credentials: settings.credentials,
+      headers:     settings.headers,
+      maxAge:      settings.maxAge
+    };
+
     if (typeof options === 'function') {
       options = options(this.request);
     }
-  
+
     if (typeof options.origin === 'function') {
       options.origin = options.origin(this.request);
     }
-  
+
     /**
      * Access Control Allow Origin
      */
     if (options.origin === false) {
       return;
     } else if (options.origin === true) {
-      options.origin = this.header.origin;
+      options.origin = this.header.origin || '*';
     } else if (!options.origin) {
       options.origin = '*';
     }
     this.set('Access-Control-Allow-Origin', options.origin);
-    
+
     /**
      * Access Control Allow Methods
      */
@@ -47,14 +53,14 @@ module.exports = function(settings) {
       options.methods = options.methods.join(',');
     }
     this.set('Access-Control-Allow-Methods', options.methods);
-    
+
     /**
      * Access Control Allow Credentials
      */
     if (options.credentials === true) {
       this.set('Access-Control-Allow-Credentials', 'true');
     }
-    
+
     /**
      * Access Control Allow Headers
      */
@@ -66,7 +72,7 @@ module.exports = function(settings) {
     if (options.headers && options.headers.length) {
       this.set('Access-Control-Allow-Headers', options.headers);
     }
-    
+
     /**
      * Access Control Allow Max Age
      */
@@ -74,14 +80,14 @@ module.exports = function(settings) {
     if (options.maxAge && options.maxAge.length) {
       this.set('Access-Control-Allow-Max-Age', options.maxAge);
     }
-    
+
     /**
      * Returns
      */
     if (this.method === 'OPTIONS') {
       this.status = 204;
     }
-    
+
   }
-  
+
 };


### PR DESCRIPTION
The settings object is being changed on the first request, causing the initial settings to persist to all requests, breaking the `origin: true` behavior.
