### PR TITLE
do not cache value of "*-Allow-Origin" header

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,19 +23,18 @@ module.exports = function(settings) {
      */
     var options = settings || defaults;
 
-    if (typeof options.origin === 'function') {
-      options.origin = options.origin(this.request);
-    }
-
     /**
      * Access Control Allow Origin
      */
-    if (options.origin === false) {
-      return;
-    } else if (typeof options.origin === 'undefined' || options.origin === true) {
-      options.origin = defaults.origin(this.request);
+    if (options.origin === false) return;
+
+    var origin;
+    if (typeof options.origin === 'string') {
+      origin = options.origin;
+    } else {
+      origin = defaults.origin(this.request);
     }
-    this.set('Access-Control-Allow-Origin', options.origin);
+    this.set('Access-Control-Allow-Origin', origin);
 
     /**
      * Access Control Expose Headers

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,21 @@ describe('cors()', function() {
       });
   });
 
+  it('should update "Access-Control-Allow-Origin" for each request', function(done) {
+    superagent.get('http://localhost:3000')
+      .end(function(response) {
+        chai.expect(response.get('Access-Control-Allow-Origin')).to.equal('*');
+
+        superagent.get('http://localhost:3000')
+          .set('Origin', 'localhost')
+          .end(function(response) {
+            chai.expect(response.get('Access-Control-Allow-Origin')).to.equal('localhost');
+
+            done();
+          });
+      });
+  });
+
   it('should not set "Access-Control-Expose-Headers"', function(done) {
     superagent.get('http://localhost:3000')
       .end(function(response) {


### PR DESCRIPTION
Previously we generated e the value of the 'Access-Control-Allow-Origin'
once with the function `defaults.origin`. However we actually intended
to use the `Origin` header of each request for itself.

See test case for more.
