### PR TITLE
Handles options.origin as function

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  * @api public
  */
 module.exports = function(settings) {
-
+  "use strict";
   var defaults = {
     origin: function(req) {
       return req.header.origin || '*';
@@ -31,9 +31,13 @@ module.exports = function(settings) {
     var origin;
     if (typeof options.origin === 'string') {
       origin = options.origin;
+    } else if (typeof options.origin === 'function') {
+      origin = options.origin(this.request);
     } else {
       origin = defaults.origin(this.request);
     }
+
+    if (origin === false) return;
     this.set('Access-Control-Allow-Origin', origin);
 
     /**
@@ -94,6 +98,6 @@ module.exports = function(settings) {
       yield next;
     }
 
-  }
+  };
 
 };

--- a/test/index.js
+++ b/test/index.js
@@ -149,6 +149,55 @@ describe('cors({ origin: false })', function() {
 
 });
 
+describe('cors({ origin: [function]})', function() {
+
+  beforeEach(function() {
+    var originWhiteList = ["localhost", "otherhost.com"];
+
+    var originFunction = function(req) {
+      var origin = req.header.origin;
+      if (originWhiteList.indexOf(origin) !== -1) {
+        return origin;
+      }
+      return false;
+    }
+
+    setupServer({ origin: originFunction });
+  });
+
+  it('should not set any "Access-Control-Allow-*" header', function(done) {
+    superagent.get('http://localhost:3000')
+    .set('Origin', 'example.com')
+      .end(function(response) {
+        chai.expect(response.get('Access-Control-Allow-Origin')).to.not.exist;
+        chai.expect(response.get('Access-Control-Allow-Methods')).to.not.exist;
+
+        done();
+      });
+  });
+
+  it('should set "Access-Control-Allow-Origin" to "otherhost.com"', function(done) {
+    superagent.get('http://localhost:3000')
+    .set('Origin', 'otherhost.com')
+      .end(function(response) {
+        chai.expect(response.get('Access-Control-Allow-Origin')).to.equal('otherhost.com');
+
+        done();
+      });
+  });
+
+  it('should set "Access-Control-Allow-Origin" to "localhost"', function(done) {
+    superagent.get('http://localhost:3000')
+    .set('Origin', 'localhost')
+      .end(function(response) {
+        chai.expect(response.get('Access-Control-Allow-Origin')).to.equal('localhost');
+
+        done();
+      });
+  });
+
+});
+
 describe('cors({ expose: "Acccept,Authorization" })', function() {
 
   beforeEach(function() {


### PR DESCRIPTION
Makes it possible to pass a function as options.origin. The function gets request object as parameter and should return the string for 'Access-Control-Allow-Origin' header, or false to prevent the header from being set.

There is a simple example in the tests.
