### PR TITLE
support using a function as the origin option

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(settings) {
     if (typeof options.origin === 'string') {
       origin = options.origin;
     } else {
-      origin = defaults.origin(this.request);
+      origin = (typeof options.origin === 'function') ? options.origin(this.request) : defaults.origin(this.request);
     }
     this.set('Access-Control-Allow-Origin', origin);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-cors",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "CORS middleware for Koa",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This was mentioned in the README, but the code didn't support passing a function as the origin option. This addresses that, as well as bumping minor version. 
