### PR TITLE
Asynchronous origin finding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
+function yieldable(something) {
+  var yieldableTypes = ['function', 'object', 'array'],
+      type = typeof something;
+  return yieldableTypes.indexOf(type) >= 0;
+}
+
 /**
  * CORS middleware
  *
@@ -28,14 +34,22 @@ module.exports = function(settings) {
      */
     if (options.origin === false) return;
 
-    var origin;
+    var getOrigin = options.origin;
 
-    if (typeof options.origin === 'string') {
-      origin = options.origin;
-    } else if (typeof options.origin === 'function') {
-      origin = options.origin(this.request);
-    } else {
-      origin = defaults.origin(this.request);
+    if (typeof getOrigin !== 'function' && typeof getOrigin !== 'string') {
+      getOrigin = defaults.origin(this.request);
+    }
+
+    if (typeof getOrigin !== 'function') {
+      getOrigin = (function(origin) {
+        return function () { return origin; };
+      }(getOrigin));
+    }
+
+    var origin = getOrigin(this.request);
+
+    if (yieldable(origin)) {
+      origin = yield origin
     }
 
     if (origin === false) return;

--- a/index.js
+++ b/index.js
@@ -36,11 +36,11 @@ module.exports = function(settings) {
 
     var getOrigin = options.origin;
 
-    if (typeof getOrigin !== 'function' && typeof getOrigin !== 'string') {
-      getOrigin = defaults.origin(this.request);
-    }
-
     if (typeof getOrigin !== 'function') {
+      if (typeof getOrigin !== 'string') {
+        getOrigin = defaults.origin(this.request);
+      }
+
       getOrigin = (function(origin) {
         return function () { return origin; };
       }(getOrigin));

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
   },
   "homepage": "https://github.com/evert0n/koa-cors",
   "devDependencies": {
-    "koa": "^0.6.1",
+    "bluebird": "^2.3.10",
     "chai": "^1.9.1",
+    "koa": "^0.6.1",
     "mocha": "^1.19.0",
     "superagent": "^0.18.0"
   }


### PR DESCRIPTION
At the moment there's no handling for asynchronous operations within the `origin` finding.

```js
cors({
  origin: function (request) {
    // ... search through database or something just as fun
  }
});
```

This pull request adds the opportunity to return anything that we can yield (promises etc).

```js
cors({
  origin: function (request) {
    return new Promise(function (resolve) {
      // some asynchronous operation
      resolve(something);
    });
  }
});
```