### PR TITLE
Access-Control-Allow-Headers determined by first request (and clean up)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "esnext": true,
+  "node": true,
+  "unused": true
+}

--- a/README.md
+++ b/README.md
@@ -31,25 +31,47 @@ app.listen(3000);
 ## Options
 
 ### origin
-Configures the **Access-Control-Allow-Origin** CORS header. Expects a string (ex: http://example.com). Set to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined by `req.header('Origin')`. Set to `false` to disable CORS. Can also be set to a function, which takes the request as the first parameter.
+
+Configures the **Access-Control-Allow-Origin** CORS header. Expects a string
+(ex: http://example.com). Set to `true` to reflect the
+[request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined
+by `req.header('Origin')`. Set to `false` to disable CORS. Can also be set to a
+function, which takes the request as the first parameter.
 
 ### expose
-Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'WWW-Authenticate,Server-Authorization') or an array (ex: `['WWW-Authenticate', 'Server-Authorization]`). Set this to pass the header, otherwise it is omitted.
+
+Configures the **Access-Control-Expose-Headers** CORS header. Expects a
+comma-delimited string (ex: 'WWW-Authenticate,Server-Authorization') or an array
+(ex: `['WWW-Authenticate', 'Server-Authorization]`). Set this to pass the
+header, otherwise it is omitted.
 
 ### maxAge
-Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
+
+Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass
+the header, otherwise it is omitted.
 
 ### credentials
-Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
+
+Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true`
+to pass the header, otherwise it is omitted.
 
 ### methods
-Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).
+
+Configures the **Access-Control-Allow-Methods** CORS header. Expects a
+comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT',
+'POST']`).
 
 ### headers
-Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Type,Authorization') or an array (ex: `['Content-Type', 'Authorization]`). If not specified, defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header.
+
+Configures the **Access-Control-Allow-Headers** CORS header. Expects a
+comma-delimited string (ex: 'Content-Type,Authorization') or an array (ex:
+`['Content-Type', 'Authorization]`). If not specified, defaults to reflecting
+the headers specified in the request's **Access-Control-Request-Headers**
+header.
 
 
-For details on the effect of each CORS header, [read this article on HTML5 Rocks](http://www.html5rocks.com/en/tutorials/cors/).
+For details on the effect of each CORS header,
+[read this article on HTML5 Rocks](http://www.html5rocks.com/en/tutorials/cors/).
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -82,13 +82,14 @@ module.exports = function(settings) {
     /**
      * Access Control Allow Headers
      */
+    var headers;
     if (!options.headers) {
-      options.headers = this.header['access-control-request-headers'];
+      headers = this.header['access-control-request-headers'];
     } else if (options.headers.join) {
-      options.headers = options.headers.join(',');
+      headers = options.headers = options.headers.join(',');
     }
-    if (options.headers && options.headers.length) {
-      this.set('Access-Control-Allow-Headers', options.headers);
+    if (headers && headers.length) {
+      this.set('Access-Control-Allow-Headers', headers);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * CORS middleware
  *
@@ -6,7 +8,6 @@
  * @api public
  */
 module.exports = function(settings) {
-  "use strict";
   var defaults = {
     origin: function(req) {
       return req.header.origin || '*';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CORS middleware for Koa",
   "main": "index.js",
   "scripts": {
-    "test": "npm test"
+    "test": "mocha test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/evert0n/koa-cors",
   "devDependencies": {
-    "koa": "^0.6.1",
-    "chai": "^1.9.1",
-    "mocha": "^1.19.0",
-    "superagent": "^0.18.0"
+    "koa": "^0.18.0",
+    "chai": "^2.0.0",
+    "mocha": "^2.1.0",
+    "superagent": "^0.21.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,20 @@ describe('cors()', function() {
       });
   });
 
+  it('should not fix value of "Access-Control-Allow-Headers"', function(done) {
+    superagent.get('http://localhost:3000')
+      .set('Access-Control-Request-Headers', 'X-Foo')
+      .end(function() {
+        superagent.get('http://localhost:3000')
+          .set('Access-Control-Request-Headers', 'X-Bar')
+          .end(function(response) {
+            chai.expect(response.get('Access-Control-Allow-Headers')).to.equal('X-Bar');
+
+            done();
+          });
+      });
+  });
+
 });
 
 describe('cors({ origin: true })', function() {


### PR DESCRIPTION
If `options.headers` is not set, it is permanently set to the value of `this.header['access-control-request-headers']` of the first request processed by this middleware. I can't see why this is the desired behavior in any case.