### PR TITLE
Prevent a cors failure to match to create a routing 404

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,10 @@ module.exports = function getMiddleware(options) {
       origin = options.origin(this.request);
     }
 
-    if (origin === false) return;
+    if (origin === false) {
+       yield next; 
+       return ;
+    }
 
     this.set('Access-Control-Allow-Origin', origin);
 

--- a/test/index.js
+++ b/test/index.js
@@ -185,7 +185,7 @@ describe('cors({ origin: [function]})', function() {
       .end(function(response) {
         chai.expect(response.get('Access-Control-Allow-Origin')).to.not.exist;
         chai.expect(response.get('Access-Control-Allow-Methods')).to.not.exist;
-
+        chai.expect(response.statusCode).to.equal(200);
         done();
       });
   });


### PR DESCRIPTION
When given a function for access-origin, a failure to match returning false caused the application to return a 404. I assume because `yield next` is never called. 
