### PR TITLE
bug with handling preflight requests in Internet Explorer 11

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = function getMiddleware(options) {
      * Returns
      */
     if (this.method === 'OPTIONS') {
-      this.status = 204;
+      this.status = 200;
     } else {
       yield next;
     }


### PR DESCRIPTION
In case with non-simple CORS, when request has
Content-Type='application/json' or request contains headers, that will
be added to "Access-Control-Request-Headers", IE11 is failed to handle
response with status 204 of "OPTIONS" request.