### PR TITLE
Fix middleware flow on false origin

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function getMiddleware(options) {
       origin = options.origin(this.request);
     }
 
-    if (origin === false) return;
+    if (origin === false) return yield next;
 
     this.set('Access-Control-Allow-Origin', origin);
 


### PR DESCRIPTION
I was experiencing an issue with my middleware chain exiting early when I returned false from a custom origin function in the cors middleware. This fixed it for me.